### PR TITLE
VOD Volunteer Round Selector

### DIFF
--- a/commands/vod_commands.py
+++ b/commands/vod_commands.py
@@ -58,43 +58,47 @@ class VodCommands(app_commands.Group, name="vod"):
             "VOD Complete Event sent!", ephemeral=True
         )
 
-    @app_commands.command(name="rounds")
-    @app_commands.checks.has_role("VOD Volunteer")
-    @app_commands.describe(rounds="number of rounds in VOD")
-    async def rounds(
+    @app_commands.command(name="get_rounds")
+    @app_commands.checks.has_role("VOD Review Team")
+    @app_commands.describe(rounds="total number of rounds in VOD")
+    async def get_rounds(
         self, interaction: Interaction, rounds: int
     ) -> None:
-        """Get rounds to be checked for VOD approval"""
+        """Genereates rounds to check for Pre-round Comms requirement"""
         if (rounds < 21):
-            await interaction.response.send_message(f"Not enough rounds in VOD\n;rejectedforfinalscore", ephemeral=True)
+            await interaction.response.send_message("Not enough rounds in VOD. Match must be 13-8 or closer.\n;rejectedforfinalscore", ephemeral=True)
             return
         generatedList = RANDOM_CLIENT.generate_integers(rounds, 1, rounds, False)
         roundsToCheck = []
-        checks = [False, False, False, False, False, False]
+        checks = [True, True, True, True, True, True]
         returnString = "Pre-round Comms:"
+        currentNum = 0
         for num in generatedList:
-            if (3 < num and num < 13 and not checks[2]):
+            currentNum = num
+            if (3 < num and num < 13 and checks[2]):
                 roundsToCheck.append(num)
-                checks[2] = True
+                checks[2] = False
                 continue
-            elif (15 < num and not checks[5]):
+            elif (15 < num and checks[5]):
                 roundsToCheck.append(num)
-                checks[5] = True
+                checks[5] = False
                 continue
-            elif (num < 4 and (not checks[0] or not checks[1])):
+            elif (num < 4 and (checks[0] or checks[1])):
                 roundsToCheck.append(num)
                 if (checks[0]):
-                    checks[1] = True
+                    checks[0] = False
                 else:
-                    checks[0] = True
+                    checks[1] = False
                 continue
-            elif (12 < num and num < 16 and (not checks[3] or not checks[4])):
+            elif (12 < num and num < 16 and (checks[3] or checks[4])):
                 roundsToCheck.append(num)
                 if (checks[3]):
-                    checks[4] = True
+                    checks[3] = False
                 else:
-                    checks[3] = True
+                    checks[4] = False
                 continue
+            if not any(checks):
+                break #early break if all checks have been completed
         roundsToCheck.sort()
         for num in roundsToCheck:
             returnString += f"\nRound {num}:"

--- a/commands/vod_commands.py
+++ b/commands/vod_commands.py
@@ -8,7 +8,8 @@ from rdoclient import RandomOrgClient
 PUBLISH_URL = "http://localhost:3000/publish-vod"
 LOG = logging.getLogger(__name__)
 AUTH_TOKEN = Config.CONFIG["Server"]["AuthToken"]
-RANDOM_CLIENT = RandomOrgClient("1c34f7d6-f990-48b7-97f0-e73e5c669d1f")
+RANDOM_ORG_API_KEY = Config.CONFIG["RandomOrg"]["ApiKey"]
+RANDOM_CLIENT = RandomOrgClient(RANDOM_ORG_API_KEY)
 
 
 @app_commands.guild_only()

--- a/commands/vod_commands.py
+++ b/commands/vod_commands.py
@@ -64,14 +64,14 @@ class VodCommands(app_commands.Group, name="vod"):
     async def rounds(
         self, interaction: Interaction, rounds: int
     ) -> None:
-        """Using Random.org, get rounds to be checked for VOD approval"""
+        """Get rounds to be checked for VOD approval"""
+        if (rounds < 21):
+            await interaction.response.send_message(f"Not enough rounds in VOD\n;rejectedforfinalscore", ephemeral=True)
+            return
         generatedList = RANDOM_CLIENT.generate_integers(rounds, 1, rounds, False)
         roundsToCheck = []
         checks = [False, False, False, False, False, False]
         returnString = "Pre-round Comms:"
-        if (rounds < 21):
-            await interaction.response.send_message(f"Not enough rounds in VOD\n;rejectedforfinalscore", ephemeral=True)
-            return
         for num in generatedList:
             if (3 < num and num < 13 and not checks[2]):
                 roundsToCheck.append(num)

--- a/config.ini.example
+++ b/config.ini.example
@@ -35,3 +35,6 @@ Username =
 Password =
 Host =
 Name =
+
+[RandomOrg]
+ApiKey =

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ quart==0.18.4
 quart_cors==0.6.0
 hypercorn==0.14.4
 pytimeparse==1.1.8
+rdoclient==1.5.0
+six==1.16.0


### PR DESCRIPTION
Adds the /vod rounds {int} command.
Uses Random.org's official API and Library to generate true random numbers that are then used to generate a list of rounds to be checked for the VOD approval process. Is only available to be ran by those with the "VOD Volunteer" role

Requires a Random.org API key, which is free under a Developer license, but feel free to use my key if you don't want to create your own: 1c34f7d6-f990-48b7-97f0-e73e5c669d1f
The API is free up to 1000 requests a day which I heavily doubt we will surpass unless someone decides to be silly and run the command over and over for no reason.